### PR TITLE
fix: 同步标签操作触发的 timestamp 自循环

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -304,29 +304,35 @@ impl Database {
 
     pub fn add_item_tag(&self, item_id: i64, tag_id: i64) -> SqlResult<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        self.conn.execute(
-            "INSERT OR REPLACE INTO item_tags (tag_id, item_id, used_at) VALUES (?1, ?2, ?3)",
+        let changed = self.conn.execute(
+            "INSERT OR IGNORE INTO item_tags (tag_id, item_id, used_at) VALUES (?1, ?2, ?3)",
             params![tag_id, item_id, now],
         )?;
-        self.touch_item(item_id)?;
+        if changed > 0 {
+            self.touch_item(item_id)?;
+        }
         Ok(())
     }
 
     pub fn remove_item_tag(&self, item_id: i64, tag_id: i64) -> SqlResult<()> {
-        self.conn.execute(
+        let deleted = self.conn.execute(
             "DELETE FROM item_tags WHERE tag_id = ?1 AND item_id = ?2",
             params![tag_id, item_id],
         )?;
-        self.touch_item(item_id)?;
+        if deleted > 0 {
+            self.touch_item(item_id)?;
+        }
         Ok(())
     }
 
     pub fn clear_item_tags(&self, item_id: i64) -> SqlResult<()> {
-        self.conn.execute(
+        let deleted = self.conn.execute(
             "DELETE FROM item_tags WHERE item_id = ?1",
             params![item_id],
         )?;
-        self.touch_item(item_id)?;
+        if deleted > 0 {
+            self.touch_item(item_id)?;
+        }
         Ok(())
     }
 
@@ -398,7 +404,6 @@ impl Database {
     }
 
     /// Insert a full item row (used during sync merge for new remote items).
-    #[allow(clippy::too_many_arguments)]
     pub fn insert_sync_item_raw(
         &self,
         item: &crate::core::sync::SyncItem,
@@ -439,8 +444,8 @@ impl Database {
     ) -> SqlResult<()> {
         self.conn.execute(
             "UPDATE clipboard_items SET full_text = ?1, content_type = ?2, updated_at = ?3,
-             rich_data = ?4, is_favorite = ?5, note = ?6, source_app_name = ?7
-             WHERE id = ?8",
+             rich_data = ?4, is_favorite = ?5, note = ?6
+             WHERE id = ?7",
             rusqlite::params![
                 item.full_text,
                 item.content_type,
@@ -448,7 +453,6 @@ impl Database {
                 item.rich_data,
                 item.is_favorite as i32,
                 item.note,
-                "", // source_app_name not in sync payload
                 id,
             ],
         )?;
@@ -461,6 +465,16 @@ impl Database {
         self.conn.execute(
             "UPDATE clipboard_items SET updated_at = ?1 WHERE id = ?2",
             rusqlite::params![now, item_id],
+        )?;
+        Ok(())
+    }
+
+    /// Set updated_at to an explicit value (used after sync merge to preserve
+    /// remote timestamp when tag re-application has bumped it to now).
+    pub fn set_item_updated_at(&self, item_id: i64, timestamp: &str) -> SqlResult<()> {
+        self.conn.execute(
+            "UPDATE clipboard_items SET updated_at = ?1 WHERE id = ?2",
+            rusqlite::params![timestamp, item_id],
         )?;
         Ok(())
     }

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -406,6 +406,9 @@ pub fn merge_remote_into_local(
                         let _ = db.add_item_tag(item_id, tag.id);
                     }
                 }
+
+                // Restore remote timestamp: add_item_tag may have bumped it.
+                let _ = db.set_item_updated_at(item_id, &remote_item.updated_at);
             }
             Some(local_item) => {
                 let remote_ts = parse_rfc3339(&remote_item.updated_at);
@@ -422,6 +425,11 @@ pub fn merge_remote_into_local(
                             let _ = db.add_item_tag(local_item.id, tag.id);
                         }
                     }
+
+                    // Restore remote timestamp: tag operations above may have
+                    // bumped updated_at via touch_item, but the item data is
+                    // semantically identical to what we just pulled from remote.
+                    let _ = db.set_item_updated_at(local_item.id, &remote_item.updated_at);
 
                     stats.items_updated += 1;
                 }


### PR DESCRIPTION
## Summary
- 修复云同步中标签操作（add/remove/clear_item_tags）无条件调用 `touch_item` 导致的 timestamp 自循环竞态
- 修复 `update_sync_item` 覆盖本地独有 `source_app_name` 导致跨设备同步后来源应用信息丢失

## 根因
1. 标签 CRUD 方法无条件将 `updated_at` 更新为当前时间，导致同步合并后本地快照语义哈希与远程不一致
2. 语义哈希不匹配触发不必要的回推，远端设备收到后再合并，timestamp 再次被更新，形成无限循环
3. `update_sync_item` 强制将 `source_app_name` 设为空字符串，销毁了设备本地独有的来源应用数据

## 修复
- `add_item_tag`: `INSERT OR REPLACE` → `INSERT OR IGNORE`，仅新建关联时 `touch_item`
- `remove_item_tag` / `clear_item_tags`: 仅在确实有行变更时才 `touch_item`
- `update_sync_item`: 移除 `source_app_name` 字段覆盖，保留本地数据
- 新增 `set_item_updated_at`: 合并完成后恢复远程时间戳，确保语义哈希与远程一致
- 移除多余 `#[allow(clippy::too_many_arguments)]` 属性

## Test plan
- [x] `cargo check` 编译通过
- [x] `cargo test` 全部 14 个测试通过
- [x] `cargo clippy` 零警告
- [x] 双设备实际同步测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)