### PR TITLE
fix: macOS 应用图标获取与类型标签显示修复

### DIFF
--- a/src/platform/focus.rs
+++ b/src/platform/focus.rs
@@ -356,31 +356,23 @@ fn windows_foreground_info() -> Option<ForegroundAppInfo> {
 
 #[cfg(target_os = "macos")]
 fn macos_foreground_info() -> Option<ForegroundAppInfo> {
-    unsafe {
-        use objc2::msg_send;
-        use objc2::rc::Retained;
-        use objc2_app_kit::NSImage;
+    let workspace = objc2_app_kit::NSWorkspace::sharedWorkspace();
+    let app = workspace.frontmostApplication()?;
 
-        let workspace = objc2_app_kit::NSWorkspace::sharedWorkspace();
-        let app = workspace.frontmostApplication()?;
-
-        if app.processIdentifier() == std::process::id() as i32 {
-            // Clippi itself — no foreground info to show
-            return None;
-        }
-
-        let name: Retained<objc2_foundation::NSString> = msg_send![&app, localizedName];
-        let app_name = name.to_string();
-
-        let icon: Option<Retained<NSImage>> = msg_send![&app, icon];
-        let icon_base64 = icon
-            .and_then(|i| super::util::nsimage_to_base64_png(&i, 32))
-            .unwrap_or_default();
-
-        Some(ForegroundAppInfo {
-            app_name,
-            window_title: String::new(), // macOS window title extraction requires extra permissions
-            icon_base64,
-        })
+    if app.processIdentifier() == std::process::id() as i32 {
+        // Clippi itself — no foreground info to show
+        return None;
     }
+
+    // Use generated methods (nil-safe via Option)
+    let app_name = app.localizedName().map(|n| n.to_string()).unwrap_or_default();
+    let icon_base64 = app.icon()
+        .and_then(|i| super::util::nsimage_to_base64_png(&i, 32))
+        .unwrap_or_default();
+
+    Some(ForegroundAppInfo {
+        app_name,
+        window_title: String::new(), // macOS window title extraction requires extra permissions
+        icon_base64,
+    })
 }

--- a/src/platform/source.rs
+++ b/src/platform/source.rs
@@ -102,31 +102,29 @@ mod macos_impl {
     use objc2_app_kit::NSWorkspace;
 
     pub fn get_clipboard_owner_info() -> Option<SourceAppInfo> {
-        unsafe {
-            use objc2::msg_send;
-            use objc2::rc::Retained;
-            use objc2_app_kit::NSImage;
+        let workspace = NSWorkspace::sharedWorkspace();
+        let app = workspace.frontmostApplication()?;
 
-            let workspace = NSWorkspace::sharedWorkspace();
-            let app = workspace.frontmostApplication()?;
-
-            // Don't record Clippi itself as the source
-            if app.processIdentifier() == std::process::id() as i32 {
-                return None;
-            }
-
-            let name: Retained<objc2_foundation::NSString> = msg_send![&app, localizedName];
-            let app_name = name.to_string();
-
-            let icon: Option<Retained<NSImage>> = msg_send![&app, icon];
-            let icon = icon?;
-            let icon_base64 = nsimage_to_base64_png(&icon, 32)?;
-
-            Some(SourceAppInfo {
-                app_name,
-                icon_base64,
-            })
+        // Don't record Clippi itself as the source
+        if app.processIdentifier() == std::process::id() as i32 {
+            return None;
         }
+
+        // Use generated methods (nil-safe via Option)
+        let app_name = app.localizedName().map(|n| n.to_string()).unwrap_or_default();
+        let icon_base64 = app.icon()
+            .and_then(|i| nsimage_to_base64_png(&i, 32))
+            .unwrap_or_default();
+
+        // Require at least a name to show source info
+        if app_name.is_empty() {
+            return None;
+        }
+
+        Some(SourceAppInfo {
+            app_name,
+            icon_base64,
+        })
     }
 }
 

--- a/src/platform/util.rs
+++ b/src/platform/util.rs
@@ -128,27 +128,119 @@ pub fn hicon_to_base64_png(hicon: windows_sys::Win32::Foundation::HANDLE, size: 
 }
 
 /// Convert an NSImage to a base64-encoded PNG.
-/// Shared by source app icon extraction and file icon extraction on macOS.
+///
+/// Uses the highest-resolution NSBitmapImageRep from the image's representations
+/// to avoid multi-page TIFF first-page issues (which can pick a tiny 16px icon).
+/// Trims transparent padding before resizing so the icon fills its display area.
 #[cfg(target_os = "macos")]
 pub fn nsimage_to_base64_png(image: &objc2_app_kit::NSImage, size: i32) -> Option<String> {
     unsafe {
         use base64::Engine;
         use objc2::msg_send;
         use objc2::rc::Retained;
+        use objc2::sel;
 
-        // Extract TIFF data from NSImage
-        let tiff: Retained<objc2::runtime::NSObject> = msg_send![image, TIFFRepresentation];
-        let bytes: *const std::ffi::c_void = msg_send![&tiff, bytes];
-        let bytes = bytes as *const u8;
-        let len: usize = msg_send![&tiff, length];
-        let tiff_bytes = std::slice::from_raw_parts(bytes, len);
+        // 1. Iterate representations to find the highest-resolution NSBitmapImageRep
+        let reps: *mut objc2::runtime::NSObject = msg_send![image, representations];
+        let count: usize = msg_send![reps, count];
+        if count == 0 {
+            return None;
+        }
 
-        // Decode TIFF → resize → encode PNG → base64
-        let img = image::load_from_memory(tiff_bytes).ok()?;
-        let resized = img.resize_exact(size as u32, size as u32, image::imageops::FilterType::Lanczos3);
-        let mut png_bytes = Vec::new();
-        resized.write_to(&mut std::io::Cursor::new(&mut png_bytes), image::ImageFormat::Png).ok()?;
+        let png_sel = sel!(representationUsingType:properties:);
+        let mut png_data: Option<Retained<objc2::runtime::NSObject>> = None;
+        let mut best_w: i32 = 0;
 
-        Some(base64::engine::general_purpose::STANDARD.encode(&png_bytes))
+        for i in 0..count {
+            let rep: *mut objc2::runtime::NSObject = msg_send![reps, objectAtIndex: i];
+            let responds: bool = msg_send![rep, respondsToSelector: png_sel];
+            if !responds {
+                continue;
+            }
+            let pw: i32 = msg_send![rep, pixelsWide];
+            if pw > best_w {
+                let data: Option<Retained<objc2::runtime::NSObject>> =
+                    msg_send![rep, representationUsingType: 4usize, properties: std::ptr::null::<objc2::runtime::NSObject>()];
+                if data.is_some() {
+                    best_w = pw;
+                    png_data = data;
+                }
+            }
+        }
+
+        // Fallback: TIFF → NSBitmapImageRep if no bitmap rep found
+        if png_data.is_none() {
+            let tiff: Retained<objc2::runtime::NSObject> = msg_send![image, TIFFRepresentation];
+            let rep: Retained<objc2::runtime::NSObject> = msg_send![
+                msg_send![objc2::class!(NSBitmapImageRep), alloc],
+                initWithData: &*tiff
+            ];
+            png_data = msg_send![&rep, representationUsingType: 4usize, properties: std::ptr::null::<objc2::runtime::NSObject>()];
+        }
+
+        let png_data = png_data?;
+
+        // 2. Extract PNG bytes from NSData
+        let bytes: *const std::ffi::c_void = msg_send![&png_data, bytes];
+        let len: usize = msg_send![&png_data, length];
+        if bytes.is_null() || len == 0 {
+            return None;
+        }
+        let png_bytes = std::slice::from_raw_parts(bytes as *const u8, len);
+
+        // 3. Decode → trim transparent padding → resize → re-encode → base64
+        let img = image::load_from_memory(png_bytes).ok()?;
+        let trimmed = trim_transparent_edges(&img);
+        let resized = trimmed.resize_exact(size as u32, size as u32, image::imageops::FilterType::Lanczos3);
+        let mut out = Vec::new();
+        resized.write_to(&mut std::io::Cursor::new(&mut out), image::ImageFormat::Png).ok()?;
+
+        Some(base64::engine::general_purpose::STANDARD.encode(&out))
     }
+}
+
+/// Crop transparent edges from an RGBA image so the content fills the frame.
+#[cfg(target_os = "macos")]
+fn trim_transparent_edges(img: &image::DynamicImage) -> image::DynamicImage {
+    let rgba = img.to_rgba8();
+    let (w, h) = rgba.dimensions();
+    if w == 0 || h == 0 {
+        return img.clone();
+    }
+
+    let threshold: u8 = 10; // treat alpha <= 10 as fully transparent
+
+    // Find bounds of non-transparent pixels
+    let mut min_x = w;
+    let mut min_y = h;
+    let mut max_x: u32 = 0;
+    let mut max_y: u32 = 0;
+
+    for y in 0..h {
+        for x in 0..w {
+            let alpha = rgba.get_pixel(x, y).0[3];
+            if alpha > threshold {
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x);
+                max_y = max_y.max(y);
+            }
+        }
+    }
+
+    // If no non-transparent pixels found, keep the original
+    if max_x < min_x || max_y < min_y {
+        return img.clone();
+    }
+
+    let crop_w = max_x - min_x + 1;
+    let crop_h = max_y - min_y + 1;
+
+    // Never crop to something unreasonably small
+    if crop_w < 8 || crop_h < 8 {
+        return img.clone();
+    }
+
+    let cropped = image::imageops::crop_imm(&rgba, min_x, min_y, crop_w, crop_h).to_image();
+    image::DynamicImage::ImageRgba8(cropped)
 }

--- a/ui/ClipboardList.slint
+++ b/ui/ClipboardList.slint
@@ -544,23 +544,9 @@ export component ClipboardList inherits Rectangle {
                                         background: tag-bg;
 
                                         st-layout := HorizontalLayout {
-                                            padding-left: 3px;
-                                            padding-right: 3px;
-                                            spacing: 2px;
+                                            padding-left: 4px;
+                                            padding-right: 4px;
                                             alignment: center;
-
-                                            st-icon := Text {
-                                                text: entry.content-type == "plain_text" ? "\u{e60e}" :
-                                                      entry.content-type == "rich_text" ? "\u{e6ae}" :
-                                                      entry.content-type == "image" ? "\u{e626}" :
-                                                      entry.content-type == "file" ? "\u{e646}" :
-                                                      entry.content-type == "link" ? "\u{e6d7}" :
-                                                      entry.content-type == "path" ? "\u{e646}" : "";
-                                                font-family: "iconfont";
-                                                font-size: 8px;
-                                                color: tag-text;
-                                                vertical-alignment: center;
-                                            }
 
                                             st-label := Text {
                                                 text: entry.content-type == "plain_text" ? "文本" :
@@ -569,7 +555,7 @@ export component ClipboardList inherits Rectangle {
                                                       entry.content-type == "file" ? entry.file-icon-text :
                                                       entry.content-type == "link" ? "URL" :
                                                       entry.content-type == "path" ? "路径" : "";
-                                                font-size: 8px;
+                                                font-size: 10px;
                                                 font-weight: 500;
                                                 color: tag-text;
                                                 vertical-alignment: center;
@@ -635,22 +621,13 @@ export component ClipboardList inherits Rectangle {
                                             clip: true;
 
                                             HorizontalLayout {
-                                                padding-left: 3px;
-                                                padding-right: 3px;
-                                                spacing: 2px;
+                                                padding-left: 4px;
+                                                padding-right: 4px;
                                                 alignment: center;
 
                                                 Text {
-                                                    text: "\u{e646}";
-                                                    font-family: "iconfont";
-                                                    font-size: 8px;
-                                                    color: tag-text;
-                                                    vertical-alignment: center;
-                                                }
-
-                                                Text {
                                                     text: entry.file-icon-text;
-                                                    font-size: 8px;
+                                                    font-size: 10px;
                                                     font-weight: 500;
                                                     color: tag-text;
                                                     vertical-alignment: center;
@@ -745,22 +722,13 @@ export component ClipboardList inherits Rectangle {
                                             clip: true;
 
                                             HorizontalLayout {
-                                                padding-left: 3px;
-                                                padding-right: 3px;
-                                                spacing: 2px;
+                                                padding-left: 4px;
+                                                padding-right: 4px;
                                                 alignment: center;
 
                                                 Text {
-                                                    text: "\u{e6d7}";
-                                                    font-family: "iconfont";
-                                                    font-size: 8px;
-                                                    color: tag-text;
-                                                    vertical-alignment: center;
-                                                }
-
-                                                Text {
                                                     text: "URL";
-                                                    font-size: 8px;
+                                                    font-size: 10px;
                                                     font-weight: 500;
                                                     color: tag-text;
                                                     vertical-alignment: center;
@@ -807,22 +775,13 @@ export component ClipboardList inherits Rectangle {
                                             clip: true;
 
                                             HorizontalLayout {
-                                                padding-left: 3px;
-                                                padding-right: 3px;
-                                                spacing: 2px;
+                                                padding-left: 4px;
+                                                padding-right: 4px;
                                                 alignment: center;
 
                                                 Text {
-                                                    text: "\u{e646}";
-                                                    font-family: "iconfont";
-                                                    font-size: 8px;
-                                                    color: tag-text;
-                                                    vertical-alignment: center;
-                                                }
-
-                                                Text {
                                                     text: "路径";
-                                                    font-size: 8px;
+                                                    font-size: 10px;
                                                     font-weight: 500;
                                                     color: tag-text;
                                                     vertical-alignment: center;


### PR DESCRIPTION
## Summary
- 修复 `nsimage_to_base64_png`：遍历 representations 取最大分辨率 NSBitmapImageRep，裁切透明边后再 resize，替代废弃的 TIFFRepresentation 方案
- 修复 `source.rs`/`focus.rs`：用生成的 nil-safe 方法替代 `unsafe msg_send!`，icon 获取失败不再级联丢弃 app_name
- 修复类型标签：font-size 8px→10px 解决 macOS 中文渲染空白；小标签去图标只保留文本

## Test plan
- [x] macOS 剪贴板列表来源应用图标正常显示
- [x] macOS 快捷键黑名单活跃应用图标正常显示
- [x] 卡片中文类型标签（文本/格式/图片/路径）正常渲染
- [x] URL 标签正常显示