### PR TITLE
重构: 统一版本迁移框架 + 同步协议版本 v2→v1

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -90,24 +90,7 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_uf_items_at ON unfavorited_items(unfavorited_at);",
         );
 
-        // Schema migration: add UNIQUE constraints to tombstone tables
-        // Without UNIQUE, INSERT OR IGNORE always inserts, causing unbounded growth.
-        let version: i64 = self.conn.pragma_query_value(None, "user_version", |r| r.get(0))?;
-        if version < 1 {
-            // Deduplicate existing rows (keep earliest entry per key)
-            self.conn.execute_batch(
-                "DELETE FROM deleted_items WHERE rowid NOT IN (SELECT MIN(rowid) FROM deleted_items GROUP BY content_hash);
-                 DELETE FROM deleted_tags WHERE rowid NOT IN (SELECT MIN(rowid) FROM deleted_tags GROUP BY name);
-                 DELETE FROM unfavorited_items WHERE rowid NOT IN (SELECT MIN(rowid) FROM unfavorited_items GROUP BY content_hash);",
-            )?;
-            // Add unique indexes so INSERT OR IGNORE actually ignores duplicates
-            self.conn.execute_batch(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_del_items_hash_uq ON deleted_items(content_hash);
-                 CREATE UNIQUE INDEX IF NOT EXISTS idx_del_tags_name_uq ON deleted_tags(name);
-                 CREATE UNIQUE INDEX IF NOT EXISTS idx_uf_items_hash_uq ON unfavorited_items(content_hash);",
-            )?;
-            self.conn.pragma_update(None, "user_version", 1)?;
-        }
+        crate::core::migration::run_db_migrations(&self.conn)?;
         Ok(())
     }
 

--- a/src/core/migration.rs
+++ b/src/core/migration.rs
@@ -1,0 +1,100 @@
+//! Unified version tracking and migration framework.
+//!
+//! Manages both database schema version (`PRAGMA user_version`) and sync
+//! protocol version (`SyncPayload.version`). The two evolve independently
+//! with one constraint: DB schema must support all fields that the current
+//! sync protocol carries.
+//!
+//! ## Adding a new database migration
+//!
+//! 1. Add an entry to `DB_MIGRATIONS` with the next sequential version number
+//! 2. Write the SQL (or leave `sql` empty and add custom logic in
+//!    `run_db_migrations` for complex data transforms)
+//! 3. Update `DB_VERSION` to match the new highest version
+//!
+//! ## Adding a new sync protocol version
+//!
+//! 1. Bump `SYNC_VERSION`
+//! 2. Add a `SyncPayload` migration step in `migrate_sync_payload` that
+//!    transforms from the old format to the current one
+
+use rusqlite::Connection;
+
+/// Current database schema version — derived from migration count (versions are 1..=N).
+#[allow(dead_code)]
+pub const DB_VERSION: i64 = DB_MIGRATIONS.len() as i64;
+
+/// Current sync protocol version — written into every `SyncPayload` snapshot.
+pub const SYNC_VERSION: u32 = 1;
+
+/// A registered database migration.
+struct DbMigration {
+    /// Sequential version number (1-based, matches `PRAGMA user_version` after applied).
+    version: i64,
+    /// Human-readable description.
+    description: &'static str,
+    /// SQL to execute (can be multiple statements separated by `;`).
+    /// Empty string means no SQL — custom logic is handled in `run_db_migrations`.
+    sql: &'static str,
+}
+
+/// Migration registry — ordered by `version` ascending.
+///
+/// Each migration is applied exactly once. To add a new migration, append an
+/// entry with the next version number and bump `DB_VERSION`.
+const DB_MIGRATIONS: &[DbMigration] = &[DbMigration {
+    version: 1,
+    description: "Add UNIQUE indexes to tombstone tables to prevent unbounded growth",
+    sql: concat!(
+        "DELETE FROM deleted_items WHERE rowid NOT IN (SELECT MIN(rowid) FROM deleted_items GROUP BY content_hash);",
+        "DELETE FROM deleted_tags WHERE rowid NOT IN (SELECT MIN(rowid) FROM deleted_tags GROUP BY name);",
+        "DELETE FROM unfavorited_items WHERE rowid NOT IN (SELECT MIN(rowid) FROM unfavorited_items GROUP BY content_hash);",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_del_items_hash_uq ON deleted_items(content_hash);",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_del_tags_name_uq ON deleted_tags(name);",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_uf_items_hash_uq ON unfavorited_items(content_hash);",
+    ),
+}];
+
+/// Run all pending database migrations, updating `PRAGMA user_version`.
+///
+/// Called from `Database::init_schema()` on every startup. Migrations that
+/// have already been applied (version <= current user_version) are skipped.
+pub fn run_db_migrations(conn: &Connection) -> rusqlite::Result<()> {
+    let current: i64 = conn.pragma_query_value(None, "user_version", |r| r.get(0))?;
+
+    debug_assert!(
+        DB_MIGRATIONS
+            .iter()
+            .enumerate()
+            .all(|(i, m)| m.version == (i + 1) as i64),
+        "DB_MIGRATIONS versions must be sequential starting from 1"
+    );
+
+    for migration in DB_MIGRATIONS {
+        if migration.version > current {
+            eprintln!("[db] migration v{} — {}", migration.version, migration.description);
+            if !migration.sql.is_empty() {
+                conn.execute_batch(migration.sql)?;
+            }
+            conn.pragma_update(None, "user_version", migration.version)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Migrate an older sync payload to the current protocol version.
+///
+/// Currently a no-op (only v1 exists). When `SYNC_VERSION` is bumped, add
+/// transform logic here to upgrade payloads from older versions.
+pub fn migrate_sync_payload(payload: &mut crate::core::sync::SyncPayload) {
+    // Example for future v2 migration:
+    //
+    // if payload.version < 2 {
+    //     // Transform v1 → v2 fields
+    //     payload.version = 2;
+    // }
+    //
+    // Always set version to current after migration.
+    let _ = payload; // Keep unused-var warning silent until first migration is added
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod color;
 pub mod db;
 pub mod filters;
 pub mod frontend;
+pub mod migration;
 pub mod paths;
 pub mod settings;
 pub mod sync;

--- a/src/core/sync.rs
+++ b/src/core/sync.rs
@@ -52,13 +52,13 @@ pub struct SyncPayload {
     pub synced_at: String, // RFC3339
     pub items: Vec<SyncItem>,
     pub tags: Vec<SyncTag>,
-    /// Deleted item tombstones (v2+).
+    /// Deleted item tombstones.
     #[serde(default)]
     pub deleted_items: Vec<SyncDeletedItem>,
-    /// Deleted tag tombstones (v2+).
+    /// Deleted tag tombstones.
     #[serde(default)]
     pub deleted_tags: Vec<SyncDeletedTag>,
-    /// Unfavorite markers (v2+).
+    /// Unfavorite markers.
     #[serde(default)]
     pub unfavorited_items: Vec<SyncUnfavoritedItem>,
 }
@@ -243,7 +243,7 @@ pub fn build_snapshot(db: &Mutex<Database>, device_name: &str, favorites_only: b
         .collect();
 
     Ok(SyncPayload {
-        version: 2,
+        version: crate::core::migration::SYNC_VERSION,
         device_name: device_name.to_string(),
         synced_at: chrono::Utc::now().to_rfc3339(),
         items: sync_items,
@@ -256,7 +256,7 @@ pub fn build_snapshot(db: &Mutex<Database>, device_name: &str, favorites_only: b
 
 // ── Merge logic ──
 
-/// Merge remote sync payload into the local database (v2, 4-phase).
+/// Merge remote sync payload into the local database (v1, 4-phase).
 ///
 /// Phases (in order):
 /// 0. Clean expired local tombstones
@@ -266,9 +266,10 @@ pub fn build_snapshot(db: &Mutex<Database>, device_name: &str, favorites_only: b
 /// 4. Merge items — create/update with last-writer-wins, skip tombstoned
 pub fn merge_remote_into_local(
     db: &Mutex<Database>,
-    remote: &SyncPayload,
+    remote: &mut SyncPayload,
     local_device_name: &str,
 ) -> Result<MergeStats, String> {
+    crate::core::migration::migrate_sync_payload(remote);
     let mut db = db.lock().map_err(|e| format!("db lock: {e}"))?;
     let mut stats = MergeStats::default();
 
@@ -596,7 +597,7 @@ mod tests {
     #[test]
     fn test_sync_payload_roundtrip() {
         let payload = SyncPayload {
-            version: 2,
+            version: crate::core::migration::SYNC_VERSION,
             device_name: "test-pc".into(),
             synced_at: "2026-05-14T10:00:00Z".into(),
             items: vec![SyncItem {
@@ -626,7 +627,7 @@ mod tests {
 
         let json = serde_json::to_string_pretty(&payload).unwrap();
         let parsed: SyncPayload = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.version, 2);
+        assert_eq!(parsed.version, crate::core::migration::SYNC_VERSION);
         assert_eq!(parsed.items.len(), 1);
         assert_eq!(parsed.items[0].tags[0].name, "work");
         assert!(parsed.deleted_items.is_empty());
@@ -662,7 +663,7 @@ mod tests {
 
     fn make_payload(items: Vec<SyncItem>, tags: Vec<SyncTag>) -> SyncPayload {
         SyncPayload {
-            version: 2,
+            version: crate::core::migration::SYNC_VERSION,
             device_name: "test".into(),
             synced_at: "2026-05-14T10:00:00Z".into(),
             items,

--- a/src/services/sync.rs
+++ b/src/services/sync.rs
@@ -551,9 +551,9 @@ fn run_sync_cycle_for_backend(
     let mut remote_hash: Option<u64> = None;
     let mut remote_unchanged = false;
     match backend.pull(force_push) {
-        Ok(remote) => {
+        Ok(mut remote) => {
             remote_hash = Some(sync::payload_semantic_hash(&remote));
-            match sync::merge_remote_into_local(db, &remote, &local_device) {
+            match sync::merge_remote_into_local(db, &mut remote, &local_device) {
                 Ok(s) => stats = s,
                 Err(e) => {
                     return (false, format!("合并远程数据失败: {e}"), stats, 0, 0);


### PR DESCRIPTION
## Summary

- 新增 `src/core/migration.rs` 统一迁移框架，管理数据库 schema 版本和同步协议版本
- 数据库迁移改为可扩展的注册表模式（`DB_MIGRATIONS` 数组），按序执行，版本号自动推导
- 同步协议版本从 v2 改为 v1（软件未发布，以当前完整协议作为 v1 基线）
- `migrate_sync_payload` 接入合并管线，后续升级同步协议时自动转换旧格式
- 迁移执行时打印 `[db] migration vN — description` 诊断日志

## Design

- DB 版本和同步版本松散关联：DB schema 须覆盖同步协议所需字段，反之不强绑
- 添加迁移：在 `DB_MIGRATIONS` 末尾追加条目即可，`DB_VERSION` 自动递增
- 协议升级：Bump `SYNC_VERSION`，在 `migrate_sync_payload` 中编写转换逻辑

## Test plan

- [x] `cargo build` 零警告
- [x] `cargo test` 19/19 通过
- [x] 全新数据库（user_version=0）正确执行 v1 迁移
- [x] 已迁移数据库（user_version>=1）正确跳过
- [x] 同步 payload 版本号验证（`test_sync_payload_roundtrip`、`test_v1_backward_compat`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)