### PR TITLE
Fix rich clipboard capture priority

### DIFF
--- a/src/core/db.rs
+++ b/src/core/db.rs
@@ -209,8 +209,8 @@ impl Database {
 
     pub fn upsert(&self, item: &ClipboardItem) -> SqlResult<()> {
         let changed = self.conn.execute(
-            "UPDATE clipboard_items SET updated_at = ?1, image_path = ?3, rich_data = ?4, file_data = ?5, image_width = ?6, image_height = ?7, size = ?8, meta_type = ?9 WHERE content_hash = ?2",
-            params![item.updated_at.to_rfc3339(), item.content_hash as i64, item.image_path, item.rich_data, item.file_data, item.image_width as i64, item.image_height as i64, item.size, item.meta_type],
+            "UPDATE clipboard_items SET updated_at = ?1, content_type = ?3, image_path = ?4, rich_data = ?5, file_data = ?6, image_width = ?7, image_height = ?8, size = ?9, meta_type = ?10 WHERE content_hash = ?2",
+            params![item.updated_at.to_rfc3339(), item.content_hash as i64, item.content_type.as_str(), item.image_path, item.rich_data, item.file_data, item.image_width as i64, item.image_height as i64, item.size, item.meta_type],
         )?;
         if changed == 0 {
             self.conn.execute(

--- a/src/platform/clipboard.rs
+++ b/src/platform/clipboard.rs
@@ -1,7 +1,7 @@
 //! --- Clipboard listener trait and platform implementations ---
 //!
 //! --- Provides multi-format clipboard monitoring with detection priority: ---
-//! --- Files > Image > Link > Color > RichText > PlainText ---
+//! --- Files > Image (Image+RichText coexistence -> Text) > Link > Color > RichText > PlainText ---
 
 use crate::core::color::detect_color;
 use crate::core::paths::images_dir;
@@ -127,12 +127,25 @@ pub trait ClipboardListener: Send {
 }
 
 /// Shared clipboard content detection (platform-agnostic).
-/// Priority: Files > Image > Link > Color > RichText > PlainText
+/// Priority: Files > Image (Image+RichText coexistence -> Text) > Link > Color > RichText > PlainText
 fn detect_clipboard_content(ctx: &ClipboardContext) -> Option<ClipboardItem> {
     // --- Capture source app info at detection time (only once, not on re-copy) ---
     let source_info = source::get_clipboard_owner_info();
+
     detect_files(ctx, &source_info)
-        .or_else(|| detect_image(ctx, &source_info))
+        .or_else(|| {
+            // When both image and rich text (HTML/RTF) coexist on the clipboard,
+            // prefer the text. Apps like OneNote and Excel put both a rendered
+            // image and formatted text on the clipboard simultaneously; users
+            // expect to see the text content, not the image rendering.
+            if ctx.has(ContentFormat::Image)
+                && (ctx.has(ContentFormat::Html) || ctx.has(ContentFormat::Rtf))
+            {
+                detect_text_content(ctx, &source_info).or_else(|| detect_image(ctx, &source_info))
+            } else {
+                detect_image(ctx, &source_info)
+            }
+        })
         .or_else(|| detect_text_content(ctx, &source_info))
 }
 

--- a/src/services/gpui_clipboard.rs
+++ b/src/services/gpui_clipboard.rs
@@ -236,7 +236,7 @@ impl GpuiClipboardService {
             // the listener detects a PlainText item with empty rich_data. If
             // the content_hash matches an existing RichText record, carry over
             // rich_data so it isn't overwritten by the upsert below.
-            if item.rich_data.is_empty() {
+            if !state.settings.copy_as_plain_text && item.rich_data.is_empty() {
                 if let Ok(Some(ref existing)) = state.db.get_by_hash(item.content_hash) {
                     if !existing.rich_data.is_empty() {
                         item.rich_data = existing.rich_data.clone();


### PR DESCRIPTION
## Summary

Fixes #43 by preserving file clipboard priority while treating image + rich-text clipboard payloads as text-first. This covers apps such as OneNote that put both a rendered image and HTML/RTF text on the clipboard.

## Details

- Keep `Files` as the highest-priority clipboard format.
- Prefer rich/text capture when non-file clipboard content contains both image and HTML/RTF formats.
- Fall back to image capture if the text path cannot read usable text.
- Honor the plain-text setting when processing repeated rich-text clipboard content.
- Update duplicate upserts so `content_type` follows the latest capture result.

## Validation

- `cargo fmt --check`
- `git diff --check`

`cargo test` / `cargo check` were intentionally not run in this pass to avoid heavy local load.